### PR TITLE
Add tile creation date and changeset Id. Add node hint to LocationReference.

### DIFF
--- a/segment.proto
+++ b/segment.proto
@@ -59,7 +59,7 @@ message Segment {
   // the road at a particular reference coordinate, or properties of the road
   // between the current LocationReference and the next.
   //
-  // the first and last LocationReference reference coordinates will be at
+  // the first and last LocationReference reference coordinates will usually be at
   // "true" intersections, which are intersections where there are multiple
   // paths through the intersection. This excludes "false" intersections where
   // two roads cross, but there are not multiple paths, such as overpasses,
@@ -74,6 +74,10 @@ message Segment {
   // numbered 1-5. locations 1 & 5 are at true intersections with other roads
   // and 2, 3 & 4 are intermediate LocationReferences inserted due to the length
   // of the road.
+  //
+  // Occasionally, a LocationReference can be inserted along a road (i.e., not at 
+  // a true intersection) to break long road segments into multiple OSMLR
+  // segments. 
   //
   message LocationReference {
     // the reference coordinate.
@@ -108,6 +112,10 @@ message Segment {
     // if the length between successive LocationReferences is more than 15km
     // then you MUST insert an intermediate LocationReference.
     optional uint32 length = 6;
+
+    // Is this LRP at a node/intersection (true) or along a road (false)?
+    // This hint can be useful wen associating OSMLR to routing graphs
+    optional bool at_node = 7;
   }
 
   // a segment is a list of at least two LocationReferences.

--- a/tile.proto
+++ b/tile.proto
@@ -35,4 +35,12 @@ message Tile {
 
   // a tile consists of a list of Entries.
   repeated Entry entries = 1;
+
+  // Creation date and time for this OSMLR tile
+  optional uint32 creation_date = 2;
+
+  // Reference to the OSM changeset Id. While not an exact representation of
+  // the state of the OSM planet file that OSMLR was derived from, this
+  // provides context on age and provenance of tile data derived from OSM.
+  optional uint64 changeset_id = 3;
 }

--- a/tile.proto
+++ b/tile.proto
@@ -36,7 +36,7 @@ message Tile {
   // a tile consists of a list of Entries.
   repeated Entry entries = 1;
 
-  // Creation date and time for this OSMLR tile
+  // Creation date and time (UTC epoch seconds) for this OSMLR tile.
   optional uint32 creation_date = 2;
 
   // Reference to the OSM changeset Id. While not an exact representation of


### PR DESCRIPTION
 Add creation date and changeset Id. This allows us to identify the age of an OSMLR tile and to match it to OSM and Valhalla data (though perhaps not exactly).

 Add a hint for whether a LocationReference is at a node (true intersection) or along an edge. LoxationReferences can be created along an edge (not at a true intersection) when an edge exceeds the max OSMLR segment length. In this case the edge is subdivided into multiple OSMLR segments by inserting LocationReferences along the road edge rather than at an intersection. This hint is helpful when associating OSMLR segments to routing data.